### PR TITLE
Fix installation as a package

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,11 +16,6 @@
 
 
 # -- Project information -----------------------------------------------------
-import os
-import sys
-sys.path.insert(0, os.path.abspath('../../openmsimodel'))
-# sys.path.insert(0, os.path.abspath('.'))
-
 project = 'openmsimodel'
 copyright = '2023, Ali Rachidi'
 author = 'Ali Rachidi'
@@ -41,10 +36,10 @@ extensions = [
     'sphinx_rtd_theme',
 ]
 
-#autodoc configs
+# autodoc configs
 autodoc_default_options = {
-    'show-inheritance':None,
-    'members':None,
+    'show-inheritance': None,
+    'members': None,
     'member-order': 'bysource',
 }
 

--- a/docs/source/dev_info/api/base_element.rst
+++ b/docs/source/dev_info/api/base_element.rst
@@ -2,4 +2,4 @@
 Base Element
 =============
 
-.. autoclass:: entity.base.base_element.BaseElement
+.. autoclass:: openmsimodel.entity.base.base_element.BaseElement

--- a/docs/source/dev_info/api/ingredient.rst
+++ b/docs/source/dev_info/api/ingredient.rst
@@ -2,4 +2,4 @@
 Ingredient
 =============
 
-.. autoclass:: entity.base.ingredient.Ingredient
+.. autoclass:: openmsimodel.entity.base.ingredient.Ingredient

--- a/docs/source/dev_info/api/material.rst
+++ b/docs/source/dev_info/api/material.rst
@@ -2,4 +2,4 @@
 Material
 =============
 
-.. autoclass:: entity.base.material.Material
+.. autoclass:: openmsimodel.entity.base.material.Material

--- a/docs/source/dev_info/api/measurement.rst
+++ b/docs/source/dev_info/api/measurement.rst
@@ -2,4 +2,4 @@
 Measurement
 =============
 
-.. autoclass:: entity.base.measurement.Measurement
+.. autoclass:: openmsimodel.entity.base.measurement.Measurement

--- a/docs/source/dev_info/api/process.rst
+++ b/docs/source/dev_info/api/process.rst
@@ -2,4 +2,4 @@
 Process
 =============
 
-.. autoclass:: entity.base.process.Process
+.. autoclass:: openmsimodel.entity.base.process.Process

--- a/docs/source/dev_info/api/process_block.rst
+++ b/docs/source/dev_info/api/process_block.rst
@@ -2,4 +2,4 @@
 Process Block
 =============
 
-.. autoclass:: subworkflow.process_block.ProcessBlock
+.. autoclass:: openmsimodel.subworkflow.process_block.ProcessBlock

--- a/docs/source/dev_info/api/subworkflow.rst
+++ b/docs/source/dev_info/api/subworkflow.rst
@@ -2,4 +2,4 @@
 Subworkflow
 =============
 
-.. autoclass:: subworkflow.subworkflow.Subworkflow
+.. autoclass:: openmsimodel.subworkflow.subworkflow.Subworkflow

--- a/docs/source/dev_info/api/workflow.rst
+++ b/docs/source/dev_info/api/workflow.rst
@@ -2,7 +2,7 @@
 Workflow
 =============
 
-.. autoclass:: workflow.workflow.Workflow
+.. autoclass:: openmsimodel.workflow.workflow.Workflow
     :imported-members:
     :members:
     :undoc-members:

--- a/openmsimodel/stores/gemd_template_store.py
+++ b/openmsimodel/stores/gemd_template_store.py
@@ -346,5 +346,6 @@ class GEMDTemplateStore(ABC):
                         yield tempdict[template_type][name].template
 
 
-all_template_stores = {"global": GEMDTemplateStore("global", load_all_files=False)}
-all_template_stores["global"].initialize_store()
+if __name__ == "__main__":
+    all_template_stores = {"global": GEMDTemplateStore("global", load_all_files=False)}
+    all_template_stores["global"].initialize_store()

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setupkwargs = dict(
     author_email="arachid1@jhu.edu",
     # license="MIT",
     # packages=['openmsimodel'],
-    packages=setuptools.find_packages(include=["openmsistream*"]),
+    packages=setuptools.find_packages(include=["openmsimodel*"]),
     # packages=find_packages(),
     zip_safe=False,
     entry_points={
@@ -21,6 +21,7 @@ setupkwargs = dict(
     install_requires=[
         "gemd",
         "methodtools",
+        "pandas",
     ],
 )
 


### PR DESCRIPTION
* Add missing `__init__` to root package folder
* fix `find_packages` to actually install files (typo)
* fix paths for autodoc
* prevent stores from being created in sys paths by default