### PR TITLE
Add widget for Cytoscape from GraphML

### DIFF
--- a/openmsimodel/graph/helpers.py
+++ b/openmsimodel/graph/helpers.py
@@ -1,9 +1,11 @@
 from yfiles_jupyter_graphs import GraphWidget
 import networkx as nx
 from webcolors import name_to_hex
-from py2cytoscape import cyrest
 import ipycytoscape
+import ipywidgets
+import traitlets
 import json
+import IPython.display
 
 
 def launch_graph_widget(g, engine="yfiles"):
@@ -25,10 +27,7 @@ def launch_graph_widget(g, engine="yfiles"):
         return name_to_hex(color)
 
     def edge_color_mapping(index, node):
-        try:
-            color = node["properties"]["color"]
-        except:
-            color = "white"
+        color = node.get("properties", {}).get("color", "white")
         return name_to_hex(color)
 
     if engine == "yfiles":
@@ -48,3 +47,69 @@ def launch_graph_widget(g, engine="yfiles"):
         display(cytoscapeobj)
         # nx.cytoscape_data(G)
         # cy.layout.apply(name="force-directed")
+
+
+_style = [
+    {
+        "selector": "node",
+        "css": {
+            "content": "data(name)",
+            "text-valign": "center",
+            "background-color": "data(color)",
+        },
+    },
+    {"selector": "node:parent", "css": {"background-opacity": 0.333}},
+    {"selector": "edge", "style": {"width": 4, "line-color": "#9dbaea"}},
+    {
+        "selector": "edge.directed",
+        "style": {
+            "curve-style": "bezier",
+            "target-arrow-shape": "triangle",
+            "target-arrow-color": "#9dbaea",
+        },
+    },
+    {"selector": "edge.multiple_edges", "style": {"curve-style": "bezier"}},
+]
+
+
+class CytoscapeGraphWidget(traitlets.HasTraits):
+    cyto_widget = traitlets.Instance(ipycytoscape.CytoscapeWidget)
+    json_display = traitlets.Instance(ipywidgets.Output)
+    graph = (
+        traitlets.Any()
+    )  # Would be nice to use a specific class here, which may be a networkx DiGraph.
+
+    @classmethod
+    def from_graphml(cls, graphml_filename):
+        g = nx.read_graphml(graphml_filename)
+        for n, d in g.nodes(data=True):
+            d.update(json.loads(d.pop("object", "{}")))
+        return cls(graph=g)
+
+    @traitlets.default("json_display")
+    def _default_json_display(self):
+        return ipywidgets.Output(layout=ipywidgets.Layout(width="30%"))
+
+    @traitlets.default("cyto_widget")
+    def _default_cyto_widget(self):
+        cw = ipycytoscape.CytoscapeWidget(layout=ipywidgets.Layout(width="70%"))
+        cw.graph.add_graph_from_networkx(self.graph)
+        cw.set_style(_style)
+
+        def update_json(node):
+            import IPython.display
+
+            with self.json_display:
+                self.json_display.clear_output(wait=True)
+                IPython.display.display(IPython.display.JSON(data=node["data"]))
+
+        cw.on("node", "click", update_json)
+        return cw
+
+    def _ipython_display_(self):
+        IPython.display.display(
+            ipywidgets.HBox(
+                [self.cyto_widget, self.json_display],
+                layout=ipywidgets.Layout(width="90%"),
+            )
+        )


### PR DESCRIPTION
(I'm not yet familiar with the standard processes for contributions to this repository, but I very much would like to learn and conform to them!)

This adds a `CytoscapeGraphWidget` for graphml files.  In one specific case, this is how I used it:

```python
import openmsimodel.graph.helpers as helpers

helpers.CytoscapeGraphWidget.from_graphml("F086-R4C3.graphml")
```

The resultant display has a JSON viewer that is updated whenever a node is selected.  It also includes some code that flattens GraphML nodes to better work with CytoscapeJS.
